### PR TITLE
Make fn ptrs in ov_callbacks Options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,11 @@ extern crate vorbis_sys;
 
 #[repr(C)]
 pub struct ov_callbacks {
-    pub read_func: extern fn(*mut libc::c_void, libc::size_t, libc::size_t, *mut libc::c_void)
-        -> libc::size_t,
-    pub seek_func: extern fn(*mut libc::c_void, ogg::ogg_int64_t, libc::c_int) -> libc::c_int,
-    pub close_func: extern fn(*mut libc::c_void) -> libc::c_int,
-    pub tell_func: extern fn(*mut libc::c_void) -> libc::c_long,
+    pub read_func: Option<extern fn(*mut libc::c_void, libc::size_t, libc::size_t, *mut libc::c_void)
+        -> libc::size_t>,
+    pub seek_func: Option<extern fn(*mut libc::c_void, ogg::ogg_int64_t, libc::c_int) -> libc::c_int>,
+    pub close_func: Option<extern fn(*mut libc::c_void) -> libc::c_int>,
+    pub tell_func: Option<extern fn(*mut libc::c_void) -> libc::c_long>,
 }
 
 // TODO: add static callbacks


### PR DESCRIPTION
I was not able to test the change because I get the following error (I'm on windows 10): 

    libvorbis/lib/misc.c(14): fatal error C1083: Cannot open include file: 'pthread.h': No such file or directory

See https://github.com/tomaka/vorbis-rs/issues/19